### PR TITLE
[WIP] Add most basic text tone analysis POC

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,18 @@ from decorators import import_decorator
 
 from markdown import render_markdown
 
+from watson_developer_cloud import ToneAnalyzerV3
+
+# See https://www.ibm.com/watson/developercloud/tone-analyzer/api/v3/python.html?python
+tone_analyzer = ToneAnalyzerV3(
+    version='2017-09-21',
+    username=os.environ.get('WATSON_API_USERNAME'),
+    password=os.environ.get('WATSON_API_PASSWORD'),
+    url='https://gateway.watsonplatform.net/tone-analyzer/api'
+)
+
+tone_analyzer.set_default_headers({'x-watson-learning-opt-out': "true"})
+
 app = Flask(__name__, static_folder='./build', static_path='')
 
 
@@ -29,6 +41,17 @@ def home():
 @app.route('/static/<path:path>')
 def send_static(path):
     return send_from_directory('./build/static', path)
+
+
+@app.route('/api/tone', methods=['POST'])
+def tone():
+    if request.json is None:
+        abort(400)
+
+    text = request.json['text']
+    tone_analysis = tone_analyzer.tone(
+        {'text': text}, 'application/json').get_result()
+    return json.dumps(tone_analysis)
 
 
 @app.route('/api/export', methods=['GET', 'POST'])

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -16,6 +16,7 @@ import ImageSource from "../entities/ImageSource";
 import ImageBlock from "../entities/ImageBlock";
 import Link from "../entities/Link";
 import ReadingTime from "../components/controls/ReadingTime";
+import SentimentAnalysis from "../components/controls/SentimentAnalysis";
 import SentryBoundary from "../components/SentryBoundary";
 
 const Container = styled.div`
@@ -118,7 +119,7 @@ const Editor = ({ rawContentState, onSave }: Props) => (
             icon: "#icon-code",
           },
         ]}
-        controls={[ReadingTime]}
+        controls={[ReadingTime, SentimentAnalysis]}
       />
     </SentryBoundary>
   </Container>

--- a/src/components/controls/SentimentAnalysis.js
+++ b/src/components/controls/SentimentAnalysis.js
@@ -1,0 +1,111 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { ToolbarButton } from "draftail";
+import { postRequest } from "../../utils";
+
+// https://console.bluemix.net/docs/services/tone-analyzer/using-tone.html#tones
+// http://kt.ijs.si/data/Emoji_sentiment_ranking/index.html
+const TONES = {
+  anger: {
+    label: "Anger",
+    emoji: "😠",
+    id: "anger",
+    description:
+      "Anger is evoked due to injustice, conflict, humiliation, negligence, or betrayal. If anger is active, the individual attacks the target, verbally or physically. If anger is passive, the person silently sulks and feels tension and hostility. (An emotional tone.)",
+  },
+  fear: {
+    label: "Fear",
+    emoji: "😨",
+    id: "fear",
+    description:
+      "Fear is a response to impending danger. It is a survival mechanism that is triggered as a reaction to some negative stimulus. Fear can be a mild caution or an extreme phobia. (An emotional tone.)",
+  },
+  joy: {
+    label: "Joy",
+    emoji: "😂",
+    id: "joy",
+    description:
+      "Joy (or happiness) has shades of enjoyment, satisfaction, and pleasure. Joy brings a sense of well-being, inner peace, love, safety, and contentment. (An emotional tone.)",
+  },
+  sadness: {
+    label: "Sadness",
+    emoji: "😢",
+    id: "sadness",
+    description:
+      "Sadness indicates a feeling of loss and disadvantage. When a person is quiet, less energetic, and withdrawn, it can be inferred that they feel sadness. (An emotional tone.)",
+  },
+  analytical: {
+    label: "Analytical",
+    emoji: "🤔",
+    id: "analytical",
+    description:
+      "An analytical tone indicates a person's reasoning and analytical attitude about things. An analytical person might be perceived as intellectual, rational, systematic, emotionless, or impersonal. (A language tone.)",
+  },
+  confident: {
+    label: "Confident",
+    emoji: "😎",
+    id: "confident",
+    description:
+      "A confident tone indicates a person's degree of certainty. A confident person might be perceived as assured, collected, hopeful, or egotistical. (A language tone.)",
+  },
+  tentative: {
+    label: "Tentative",
+    emoji: "😕",
+    id: "tentative",
+    description:
+      "A tentative tone indicates a person's degree of inhibition. A tentative person might be perceived as questionable, doubtful, or debatable. (A language tone.)",
+  },
+};
+
+class SentimentAnalysis extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      sentiment: null,
+    };
+  }
+
+  componentDidMount() {
+    const { getEditorState } = this.props;
+
+    setInterval(() => {
+      const editorState = getEditorState();
+      const content = editorState.getCurrentContent();
+      const text = content.getPlainText();
+
+      postRequest("/api/tone", { text }, (analysis) => {
+        const tone = analysis.document_tone.tones.reduce((best, t) => {
+          if (best) {
+            return t.score > best.score ? t : best;
+          }
+
+          return t;
+        }, null);
+        this.setState({
+          sentiment: TONES[tone.tone_id],
+        });
+      });
+    }, 10000);
+  }
+  render() {
+    const { sentiment } = this.state;
+
+    return (
+      <ToolbarButton
+        name="SENTIMENT_ANALYSIS"
+        label={sentiment ? `${sentiment.label} ${sentiment.emoji}` : "…"}
+        onClick={() => {
+          // eslint-disable-next-line no-alert
+          window.alert(sentiment ? sentiment.description : null);
+        }}
+      />
+    );
+  }
+}
+
+SentimentAnalysis.propTypes = {
+  getEditorState: PropTypes.func.isRequired,
+};
+
+export default SentimentAnalysis;


### PR DESCRIPTION
This is built with the Tone Analyzer API of IBM Watson: https://www.ibm.com/watson/developercloud/tone-analyzer/api/v3/python.html?python.

![sentiment-analysis-poc](https://user-images.githubusercontent.com/877585/46769782-8417b480-ccf5-11e8-8fc0-8cd4c31d1097.gif)

The integration is really basic – it adds a Draftail control that displays the tone with the highest score. Tone is queried every 10 seconds.

---

I won't merge it as-is, but it's a good showcase of using third-party / HTTP APIs with Draftail – might rebuild this with NLTK to make it publishable, or assess that IBM Watson has a nice enough free tier for this to be published.